### PR TITLE
Add file locking to avoid double-processing

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,3 @@
-## Description
-
 <!--
 Please provide a meaningful description of what this change will do, or is for. Bonus points for including links to related issues, other PRs, or technical references.
 

--- a/internal/s3/s3.go
+++ b/internal/s3/s3.go
@@ -3,8 +3,10 @@ package s3
 import (
 	"fmt"
 	"io"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/impossiblecloud/s3-file-uploader/internal/cfg"
 	"github.com/impossiblecloud/s3-file-uploader/internal/utils"
@@ -73,6 +75,10 @@ func FakeUploadFile(config cfg.AppConfig, filename string) (int64, error) {
 		config.Applog.Error(err)
 		return 0, err
 	}
+
+	// Simulate random upload time by sleeping for a random duration
+	sleepSec := rand.IntN(10) + 5
+	time.Sleep(time.Duration(sleepSec) * time.Second)
 
 	config.Applog.Infof("FAKE UPLOAD TO S3: %q file, size %s", realFile, utils.HumanizeBytes(fi.Size(), false))
 	return fi.Size(), nil

--- a/main.go
+++ b/main.go
@@ -247,6 +247,7 @@ func worker(wg *sync.WaitGroup, ctx context.Context, id int, config cfg.AppConfi
 			}
 
 			applog.Infof("Worker %d: processing file %q", id, msg.File)
+			fs.Lock(msg.File, id)
 
 			config.Metrics.FileSendCount.WithLabelValues().Inc()
 			err := sendFileS3(config, client, msg.File)
@@ -256,6 +257,7 @@ func worker(wg *sync.WaitGroup, ctx context.Context, id int, config cfg.AppConfi
 			} else {
 				config.Metrics.FileSendSuccess.WithLabelValues().Inc()
 			}
+			fs.UnLock(msg.File)
 		}
 	}
 }


### PR DESCRIPTION
If sending file takes more time than dir scan interval (10s default) it may cause to trigger processing of the same file twice+. Let's add some primitive locking mechanism to avoid that.

## Type of Change

- [x] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)
